### PR TITLE
fix json structure in quick_link.py script

### DIFF
--- a/quick_link.py
+++ b/quick_link.py
@@ -92,7 +92,8 @@ def load_config(argv):
     if len(argv) > 1:
         path = argv[1]
         with open(path, "r", encoding="utf-8") as f:
-            return json.load(f)["settings"]
+            data = json.load(f)
+            return data.get("settings", data)
     return CONFIG
 
 

--- a/quick_link.py
+++ b/quick_link.py
@@ -92,7 +92,7 @@ def load_config(argv):
     if len(argv) > 1:
         path = argv[1]
         with open(path, "r", encoding="utf-8") as f:
-            return json.load(f)
+            return json.load(f)["settings"]
     return CONFIG
 
 


### PR DESCRIPTION
Столкнулся с проблемой создания "1-Click" ссылки из JSON конфига
<img width="1178" height="79" alt="image" src="https://github.com/user-attachments/assets/28d8d52b-0be5-4daa-8805-0fe5e29da44f" />

Экспорт из приложения создает JSON с объектом settings, содержащем информация о конфигурации, но скрипт пытается найти конфигурацию в корневом словаре.
Т.е. ожидает структуру типа:
```
{
    "allowedIPs" : "0.0.0.0\/0",
    "credPoolCooldownSeconds" : 150,
    "dnsServers" : "8.8.8.8"
    ...
} 
```

Сделал извлечение конфигурации по ключу settings