### PR TITLE
ui fixes: высота поля для vk call link, закрытие клавиатуры при нажатии вне поля ввода

### DIFF
--- a/VKTurnProxy/VKTurnProxy.xcodeproj/project.pbxproj
+++ b/VKTurnProxy/VKTurnProxy.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		CFADBA590C4935186A057FB9 /* LiveActivityIntents.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFF216A96C8B2716DA861C50 /* LiveActivityIntents.swift */; };
 		E1250E1BF6D8FBFBCCFB25BF /* VKProfileCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48CEB6CB28E1CC064B6D8C79 /* VKProfileCache.swift */; };
 		EED41432670F89B23A9658A9 /* VKTurnProxyWidget.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 196C853F06BE5F3D3202EA2D /* VKTurnProxyWidget.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		509BF755A1015D2DED6293B0 /* KeyboardDismisser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02DE095CE95FF11F5828F516 /* KeyboardDismisser.swift */; };
 		F0801AAE2F21FAF8BBED6622 /* VKCallsAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB18A0573ABD15BB23B9E7D7 /* VKCallsAPI.swift */; };
 		F11AED7C7036E8FA47F81179 /* AppEntitlements.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0725E9EC1D6D9B4E406EB36B /* AppEntitlements.swift */; };
 		F32EA8BA9CCC4E95BD4DFA12 /* NetworkExtension.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 605ED1D89D0F1886A8414767 /* NetworkExtension.framework */; };
@@ -124,6 +125,7 @@
 		DDB21244CBAB1A5B17A5CF06 /* WidgetKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WidgetKit.framework; path = System/Library/Frameworks/WidgetKit.framework; sourceTree = SDKROOT; };
 		E28ACD6367F3CDE026C71A36 /* PacketTunnel.appex */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = "wrapper.app-extension"; path = PacketTunnel.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		E74B178DC212A229BC8565F4 /* TunnelManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TunnelManager.swift; sourceTree = "<group>"; };
+		02DE095CE95FF11F5828F516 /* KeyboardDismisser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardDismisser.swift; sourceTree = "<group>"; };
 		EB18A0573ABD15BB23B9E7D7 /* VKCallsAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VKCallsAPI.swift; sourceTree = "<group>"; };
 		F16CAECB3D91AC18F93D32C0 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		FC7905B75584E8ECB5B29CDF /* ServerStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerStore.swift; sourceTree = "<group>"; };
@@ -208,6 +210,7 @@
 				A3F6AB47B5515172AD460053 /* ContentView.swift */,
 				B72BF34DDA41B9171843CDA5 /* CredCache.swift */,
 				3979E0E80EBC90588B51D4A5 /* Info.plist */,
+				02DE095CE95FF11F5828F516 /* KeyboardDismisser.swift */,
 				8B1A512B35CE1D505CB1A3CD /* LiveActivityController.swift */,
 				CFF216A96C8B2716DA861C50 /* LiveActivityIntents.swift */,
 				B579DDFDDB7800E681CAC9C4 /* OSLogReader.swift */,
@@ -403,6 +406,7 @@
 				23FB3FA154A0B74AE5DFB39C /* ConfigValidation.swift in Sources */,
 				96F82C428BBBE30E65182344 /* ContentView.swift in Sources */,
 				2263C90DC75E56A0D637B2B4 /* CredCache.swift in Sources */,
+				509BF755A1015D2DED6293B0 /* KeyboardDismisser.swift in Sources */,
 				C272EDFB69425D4F95736DE9 /* LiveActivityController.swift in Sources */,
 				3A638CAC10B3F4B84965F83F /* LiveActivityIntents.swift in Sources */,
 				9FC59D2A14AA5E66C86F6C95 /* OSLogReader.swift in Sources */,

--- a/VKTurnProxy/VKTurnProxy/ContentView.swift
+++ b/VKTurnProxy/VKTurnProxy/ContentView.swift
@@ -7,6 +7,26 @@ import os.log
 
 private let captchaLog = OSLog(subsystem: "com.vkturnproxy.app", category: "Captcha")
 
+extension View {
+    /// Lets a drag on empty Form/List space dismiss the keyboard, the way
+    /// Apple's own Settings app behaves. `.scrollDismissesKeyboard` is the
+    /// framework's own mechanism — unlike a hand-rolled UIKit tap-gesture
+    /// hack (tried and reverted: it broke focus entirely on this SwiftUI
+    /// build, keyboard never appeared at all for ANY field), it is
+    /// guaranteed to compose correctly with SwiftUI's own focus handling
+    /// since Apple implements both. iOS 16+ only; the app's floor is iOS
+    /// 15.0, so pre-16 just keeps the original behavior (dismiss via
+    /// return/back, same as before this fix existed).
+    @ViewBuilder
+    func dismissKeyboardOnDrag() -> some View {
+        if #available(iOS 16.0, *) {
+            self.scrollDismissesKeyboard(.interactively)
+        } else {
+            self
+        }
+    }
+}
+
 struct ContentView: View {
     @StateObject private var tunnel = TunnelManager.shared
 
@@ -458,7 +478,10 @@ struct SettingsView: View {
                          : "VK Call Link")
                         .font(.caption).foregroundColor(.secondary)
                     TextEditor(text: $vkLink)
-                        .frame(minHeight: vkAuthEnabled ? 110 : 38)
+                        // 38pt was ~1 line — a real join link (vk.ru/call/join/<hash>)
+                        // wraps to 2-3 lines at typical widths and got clipped inside
+                        // the field with no visual hint there was more to scroll to.
+                        .frame(minHeight: vkAuthEnabled ? 110 : 70)
                         .autocapitalization(.none)
                         .disableAutocorrection(true)
                 }
@@ -599,6 +622,7 @@ struct SettingsView: View {
                 Text("Backup contains all settings, WireGuard keys, TURN credentials, and the captured browser profile. Treat the exported file as a secret.")
             }
         }
+        .dismissKeyboardOnDrag()
         .navigationTitle("Settings")
         // Share sheet for the freshly-exported temp file. Bound to a
         // sheet(item:) so the file is in scope while the sheet is open

--- a/VKTurnProxy/VKTurnProxy/KeyboardDismisser.swift
+++ b/VKTurnProxy/VKTurnProxy/KeyboardDismisser.swift
@@ -1,0 +1,97 @@
+import SwiftUI
+import UIKit
+
+/// Tapping empty space should dismiss the keyboard, same as almost every
+/// other iOS app. SwiftUI's Form/List swallow a plain `.onTapGesture` placed
+/// on their background before it ever reaches the gaps between rows, so a
+/// per-screen modifier doesn't work here. This installs ONE
+/// UITapGestureRecognizer directly on the window instead — outside SwiftUI's
+/// hit-testing entirely — with `cancelsTouchesInView = false` so it never
+/// blocks a button, row tap, or anything else already listening; it only
+/// ever adds "also resign the keyboard" on top of whatever that tap already
+/// does.
+///
+/// An earlier version of this file was reverted after the keyboard stopped
+/// appearing at all in testing. Root cause turned out to be unrelated:
+/// stale iOS Simulator state (fixed by Simulator → Device → Erase All
+/// Content and Settings) — confirmed by the SAME failure reproducing on a
+/// completely clean checkout with none of this code present. Restored.
+
+/// Standard "find the current first responder" trick — UIResponder exposes
+/// no direct API for it, so this asks the responder chain itself: `sendAction`
+/// with a nil target routes to whatever IS first responder, which records
+/// itself here.
+private extension UIResponder {
+    private static weak var _currentFirstResponder: UIResponder?
+
+    static var currentFirstResponder: UIResponder? {
+        _currentFirstResponder = nil
+        UIApplication.shared.sendAction(#selector(captureFirstResponder), to: nil, from: nil, for: nil)
+        return _currentFirstResponder
+    }
+
+    @objc private func captureFirstResponder() {
+        UIResponder._currentFirstResponder = self
+    }
+}
+
+/// Gesture recognizers do not retain their target, so this needs to live for
+/// the app's lifetime — a singleton does that.
+///
+/// The delegate check runs at touch-DOWN, i.e. before this tap could have
+/// changed focus yet, so "the current first responder" here really means
+/// "what was focused before this tap":
+///   - nothing focused yet → nothing to dismiss → don't even recognize the
+///     gesture. This is what makes tapping a field for the first time safe:
+///     our recognizer stays out of it entirely, so it cannot race the
+///     field's own focus-gain.
+///   - something IS focused and this tap lands OUTSIDE its bounds (empty
+///     row space, a different field, a button, ...) → recognize, and
+///     `handleTap` resigns it. cancelsTouchesInView = false means the touch
+///     still reaches whatever was actually tapped afterward — a tap on a
+///     DIFFERENT field still focuses that field normally; iOS already
+///     resigns the old responder as part of that regardless of us.
+///   - something focused and the tap is INSIDE its own bounds (repositioning
+///     the cursor in the field you're already editing) → don't recognize,
+///     don't interrupt.
+private final class KeyboardDismissTarget: NSObject, UIGestureRecognizerDelegate {
+    static let shared = KeyboardDismissTarget()
+
+    @objc func handleTap(_ sender: UITapGestureRecognizer) {
+        sender.view?.endEditing(true)
+    }
+
+    func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldReceive touch: UITouch) -> Bool {
+        guard let responderView = UIResponder.currentFirstResponder as? UIView else { return false }
+        let point = touch.location(in: responderView)
+        return !responderView.bounds.contains(point)
+    }
+}
+
+/// Finds its own window via `didMoveToWindow` and wires the gesture to it
+/// exactly once (guarded by `name` so re-mounting this invisible view, e.g.
+/// on a scene change, never stacks up duplicate recognizers).
+private final class KeyboardDismissAnchor: UIView {
+    override func didMoveToWindow() {
+        super.didMoveToWindow()
+        guard let window,
+              window.gestureRecognizers?.contains(where: { $0.name == "keyboardDismiss" }) != true
+        else { return }
+        let tap = UITapGestureRecognizer(
+            target: KeyboardDismissTarget.shared,
+            action: #selector(KeyboardDismissTarget.handleTap(_:))
+        )
+        tap.name = "keyboardDismiss"
+        tap.cancelsTouchesInView = false
+        tap.delegate = KeyboardDismissTarget.shared
+        window.addGestureRecognizer(tap)
+    }
+}
+
+/// SwiftUI wrapper for `KeyboardDismissAnchor`. Attach once, at the
+/// WindowGroup root — every screen shares the same window, so one instance
+/// covers the whole app (main screen, Settings, ServerEditView, ...).
+struct KeyboardDismisser: UIViewRepresentable {
+    func makeUIView(context: Context) -> UIView { KeyboardDismissAnchor(frame: .zero) }
+    func updateUIView(_ uiView: UIView, context: Context) {}
+}

--- a/VKTurnProxy/VKTurnProxy/ServerEditView.swift
+++ b/VKTurnProxy/VKTurnProxy/ServerEditView.swift
@@ -188,6 +188,7 @@ struct ServerEditView: View {
                 Text("New creates a server with default settings. Copy duplicates this one. The last server can't be deleted. vkLink and VK account auth are global (Settings screen), not per-server.")
             }
         }
+        .dismissKeyboardOnDrag()
         .navigationTitle(draft.serverName.isEmpty ? "Server" : draft.serverName)
         .navigationBarTitleDisplayMode(.inline)
         // Persist every edit through the store (projects onto the flat keys when

--- a/VKTurnProxy/VKTurnProxy/VKTurnProxyApp.swift
+++ b/VKTurnProxy/VKTurnProxy/VKTurnProxyApp.swift
@@ -63,6 +63,11 @@ struct VKTurnProxyApp: App {
                         ConnectionLinkInbox.shared.pendingURL = url
                     }
                 }
+                // Tap-anywhere-to-dismiss-keyboard, wired at the window level
+                // (see KeyboardDismisser.swift) — a plain SwiftUI tap gesture
+                // doesn't reach the empty space inside Form/List, so this is
+                // attached once here for every screen instead.
+                .background(KeyboardDismisser())
         }
     }
 }


### PR DESCRIPTION
## 1. Поле "VK Call Link" обрезало вставленную ссылку

В ContentView.swift поле для VK-ссылки (`TextEditor`) было слишком узким по высоте (`minHeight: 38` — фактически одна строка), а реальная join-ссылка (`vk.ru/call/join/<hash>`) заворачивается на 2-3 строки. Увеличил `minHeight` до 70 — теперь вставленная ссылка видна целиком, без обрезания.

## 2. Клавиатура не закрывалась по тапу мимо поля

Раньше единственный способ убрать клавиатуру был "Назад" — тап по пустому месту экрана ничего не делал. Сделал два независимых механизма, которые работают вместе:

- **KeyboardDismisser.swift** (новый файл) — жест-тап, повешенный на уровень окна приложения (а не на конкретный экран), с аккуратной логикой: если что-то в фокусе и тап пришёлся **вне** его границ — клавиатура закрывается; если тап пришёлся **на** само поле (или ничего ещё не в фокусе) — жест не срабатывает вообще, чтобы не мешать полю получить фокус. Работает сразу на всех экранах.
- Дополнительно на оба экрана с формами — клавиатура закрывается ещё и лёгким свайпом по пустому месту, как в системных Настройках iOS.